### PR TITLE
change behavior of Coupon value readers

### DIFF
--- a/lib/fastbill-automatic/coupon.rb
+++ b/lib/fastbill-automatic/coupon.rb
@@ -2,10 +2,30 @@ module Fastbill
   module Automatic
     class Coupon < Base
 
-      attr_reader :code, :title, :discount, :discount_period, :valid_from, :valid_to, :assigned_articles
+      attr_reader :code, :title, :discount, :discount_period, :assigned_articles
 
       def self.create(attributes)
         raise FastbillError.new('Create method not implemented.')
+      end
+
+      def usages
+        @usages.to_i
+      end
+
+      def usages_max
+        @usages_max.to_i
+      end
+
+      def discount_amount
+        @discount_amount.to_f
+      end
+
+      def valid_from
+        Date.new *@valid_from.split("-").map(&:to_i)
+      end
+
+      def valid_to
+        Date.new *@valid_to.split("-").map(&:to_i)
       end
     end
   end


### PR DESCRIPTION
For easier access of Coupon values I defined attribute readers myself, parsing the string values to the most commonly needed use case Classes (valid_from to Date, e.g.).
